### PR TITLE
Fix missing node version number

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -344,7 +344,6 @@ Node.prototype.getInfo = function()
 	console.time('Got info');
 
 	try {
-		this.info.coinbase = web3.eth.coinbase;
                 try {
                         this.info.coinbase = web3.eth.coinbase;
                 }
@@ -352,6 +351,7 @@ Node.prototype.getInfo = function()
                         console.log("Couldn't get coinbase, using zero address instead. Err = " + e);
                         this.info.coinbase = "0x0000000000000000000000000000000000000000";
                 }
+		this.info.node = web3.version.node;
 		this.info.net = web3.version.network;
 		this.info.protocol = web3.toDecimal(web3.version.ethereum);
 		this.info.api = web3.version.api;

--- a/lib/node.js
+++ b/lib/node.js
@@ -345,7 +345,13 @@ Node.prototype.getInfo = function()
 
 	try {
 		this.info.coinbase = web3.eth.coinbase;
-		this.info.node = web3.version.node;
+                try {
+                        this.info.coinbase = web3.eth.coinbase;
+                }
+                catch (e) {
+                        console.log("Couldn't get coinbase, using zero address instead. Err = " + e);
+                        this.info.coinbase = "0x0000000000000000000000000000000000000000";
+                }
 		this.info.net = web3.version.network;
 		this.info.protocol = web3.toDecimal(web3.version.ethereum);
 		this.info.api = web3.version.api;
@@ -356,7 +362,7 @@ Node.prototype.getInfo = function()
 		return true;
 	}
 	catch (err) {
-		console.error("Couldn't get version");
+		console.error("Couldn't get version: " + err);
 	}
 
 	return false;


### PR DESCRIPTION
Newer versions of parity don't return zero address in `eth_coinbase` when no accounts exist (https://github.com/paritytech/parity-ethereum/pull/9383). It prevents netstats agent from obtaining correct node version info.